### PR TITLE
AppAuth 디펜던시 추가

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,8 @@ let package = Package(
       name: "GTMAppAuth",
       dependencies: [
         .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
-        .product(name: "AppAuthCore", package: "AppAuth-iOS")
+        .product(name: "AppAuthCore", package: "AppAuth-iOS"),
+        .product(name: "AppAuth", package: "AppAuth-iOS")
       ],
       path: "GTMAppAuth/Sources",
       resources: [.copy("Resources/PrivacyInfo.xcprivacy")],


### PR DESCRIPTION
## 수정 사항
- 원앱에서 `authState(byPresenting:presenting:callback:)` 메소드를 사용하기 위해 디펜던시 추가

## 참고 사항
- 정확한 이유는 알 수 없으나 추가적인 디펜던시가 필요하다면 직접 수정해서 사용하라고 가이드를 하고 있음
  - https://github.com/google/GTMAppAuth/issues/118